### PR TITLE
Dunfell

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # meta-ci.os
 CI4Rail Top Level Yocto Layer
+
+## Ci4Rail specific modifications:
+* `recipes-images/images/tdx-reference-minimal-image.bbappend`
+Modifies variables to enable versioning using environment variables: `IMAGE_GIT_VERSION` for versioning and `IMAGE_NAME_SUFFIX` for tagging a development build.
+
+## 3rd Party layer modifications:
+* `recipes-core/base-files/base_files_3.0.14.bbappend`
+fixes `fstab` file to work with read-only filesystem. Read-only filesystem is needed for mender delta-update support, but `meta-toradex-demo` provides an own fstab that is not compatible with `openembedded-core`'s way to enable read-only. Enabling read-only is done with sed by patching the fstab file (https://github.com/openembedded/openembedded-core/blob/master/meta/classes/rootfs-postcommands.bbclass#L95-L98). This won't work with the fstab provided by `meta-toradex-demo`.

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -1,0 +1,13 @@
+# We have a conf and classes directory, add to BBPATH
+BBPATH .= ":${LAYERDIR}"
+
+# We have recipes-* directories, add to BBFILES
+BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
+            ${LAYERDIR}/recipes-*/*/*.bbappend"
+
+BBFILE_COLLECTIONS += "meta-ci.os"
+BBFILE_PATTERN_meta-ci.os = "^${LAYERDIR}/"
+BBFILE_PRIORITY_meta-ci.os = "6"
+
+LAYERDEPENDS_meta-ci.os = "core"
+LAYERSERIES_COMPAT_meta-ci.os = "dunfell"

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -7,7 +7,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 
 BBFILE_COLLECTIONS += "meta-ci.os"
 BBFILE_PATTERN_meta-ci.os = "^${LAYERDIR}/"
-BBFILE_PRIORITY_meta-ci.os = "6"
+BBFILE_PRIORITY_meta-ci.os = "99"
 
 LAYERDEPENDS_meta-ci.os = "core"
 LAYERSERIES_COMPAT_meta-ci.os = "dunfell"

--- a/recipes-core/base-files/base-files/fstab
+++ b/recipes-core/base-files/base-files/fstab
@@ -1,0 +1,12 @@
+# stock fstab - you probably want to override this with a machine specific one
+
+/dev/root            /                    auto       defaults              1  1
+proc                 /proc                proc       defaults              0  0
+devpts               /dev/pts             devpts     mode=0620,gid=5       0  0
+usbdevfs             /proc/bus/usb        usbdevfs   noauto                0  0
+tmpfs                /run                 tmpfs      mode=0755,nodev,nosuid,strictatime 0  0
+tmpfs                /var/volatile        tmpfs      defaults              0  0
+
+# uncomment this if your device has a SD/MMC/Transflash slot
+#/dev/mmcblk0p1       /media/card          auto       defaults,sync,noauto  0  0
+

--- a/recipes-core/base-files/base-files_3.0.14.bbappend
+++ b/recipes-core/base-files/base-files_3.0.14.bbappend
@@ -1,0 +1,1 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/base-files:"

--- a/recipes-images/images/tdx-reference-minimal-image.bbappend
+++ b/recipes-images/images/tdx-reference-minimal-image.bbappend
@@ -1,0 +1,4 @@
+GIT_VERSION := "${@d.getVar('BB_ORIGENV',False).getVar('IMAGE_GIT_VERSION', False) or 'NoVersion'}"
+NAME_SUFFIX := "${@d.getVar('BB_ORIGENV',False).getVar('IMAGE_NAME_SUFFIX', False) or ''}"
+IMAGE_VERSION =  "CI.OS.LMP-${GIT_VERSION}"
+IMAGE_NAME = "${MACHINE_NAME}_${IMAGE_BASENAME}_${IMAGE_VERSION}${NAME_SUFFIX}"


### PR DESCRIPTION
Note: This PR gets used by ci4rail/ci.os.lmp#5
- [x] Added versioning
- [x] workaround for read-only root fs