### PR TITLE
Added persistent-journald

### DIFF
--- a/recipes-overlays/overlay-directories/overlay-directories.bb
+++ b/recipes-overlays/overlay-directories/overlay-directories.bb
@@ -19,7 +19,7 @@ SYSTEMD_AUTO_ENABLE = "enable"
 do_install() {
     install -d ${D}${bindir}
     install -d ${D}${systemd_system_unitdir}
-   
+    
     cat <<EOF > ${D}${CREATE_OVERLAY_DIRECTORIES_SCRIPT}
 #!/bin/sh
 # create docker overlay directories
@@ -35,16 +35,11 @@ mkdir -p ${IOTEDGE_OVERLAY_CONFIG_WORK_DIR}
 mkdir -p ${IOTEDGE_OVERLAY_RUN_ROOT_DIR}
 mkdir -p ${IOTEDGE_OVERLAY_RUN_UPPER_DIR}
 mkdir -p ${IOTEDGE_OVERLAY_RUN_WORK_DIR}
-# journald run
-mkdir -p ${JOURNAL_OVERLAY_RUN_ROOT_DIR}
-mkdir -p ${JOURNAL_OVERLAY_RUN_UPPER_DIR}
-mkdir -p ${JOURNAL_OVERLAY_RUN_WORK_DIR}
 
 # mount overlays
 mount -t overlay overlay -o lowerdir=${DOCKER_OVERLAY_CONFIG_LOWER_DIR},upperdir=${DOCKER_OVERLAY_CONFIG_UPPER_DIR},workdir=${DOCKER_OVERLAY_CONFIG_WORK_DIR} ${DOCKER_OVERLAY_CONFIG_LOWER_DIR}
 mount -t overlay overlay -o lowerdir=${IOTEDGE_OVERLAY_CONFIG_LOWER_DIR},upperdir=${IOTEDGE_OVERLAY_CONFIG_UPPER_DIR},workdir=${IOTEDGE_OVERLAY_CONFIG_WORK_DIR} ${IOTEDGE_OVERLAY_CONFIG_LOWER_DIR}
 mount -t overlay overlay -o lowerdir=${IOTEDGE_OVERLAY_RUN_LOWER_DIR},upperdir=${IOTEDGE_OVERLAY_RUN_UPPER_DIR},workdir=${IOTEDGE_OVERLAY_RUN_WORK_DIR} ${IOTEDGE_OVERLAY_RUN_LOWER_DIR}
-mount -t overlay overlay -o lowerdir=${JOURNAL_OVERLAY_RUN_LOWER_DIR},upperdir=${JOURNAL_OVERLAY_RUN_UPPER_DIR},workdir=${JOURNAL_OVERLAY_RUN_WORK_DIR} ${JOURNAL_OVERLAY_RUN_LOWER_DIR}
 
 # make lower dir of iotedge writeable. This needs to be done in order that iotedge can start properly.
 # meta-iotedge creates a user and group `iotedge:iotedge`. The service is run as this user.

--- a/recipes-overlays/overlay-directories/overlay-directories.bb
+++ b/recipes-overlays/overlay-directories/overlay-directories.bb
@@ -35,11 +35,16 @@ mkdir -p ${IOTEDGE_OVERLAY_CONFIG_WORK_DIR}
 mkdir -p ${IOTEDGE_OVERLAY_RUN_ROOT_DIR}
 mkdir -p ${IOTEDGE_OVERLAY_RUN_UPPER_DIR}
 mkdir -p ${IOTEDGE_OVERLAY_RUN_WORK_DIR}
+# journald run
+mkdir -p ${JOURNAL_OVERLAY_RUN_ROOT_DIR}
+mkdir -p ${JOURNAL_OVERLAY_RUN_UPPER_DIR}
+mkdir -p ${JOURNAL_OVERLAY_RUN_WORK_DIR}
 
 # mount overlays
 mount -t overlay overlay -o lowerdir=${DOCKER_OVERLAY_CONFIG_LOWER_DIR},upperdir=${DOCKER_OVERLAY_CONFIG_UPPER_DIR},workdir=${DOCKER_OVERLAY_CONFIG_WORK_DIR} ${DOCKER_OVERLAY_CONFIG_LOWER_DIR}
 mount -t overlay overlay -o lowerdir=${IOTEDGE_OVERLAY_CONFIG_LOWER_DIR},upperdir=${IOTEDGE_OVERLAY_CONFIG_UPPER_DIR},workdir=${IOTEDGE_OVERLAY_CONFIG_WORK_DIR} ${IOTEDGE_OVERLAY_CONFIG_LOWER_DIR}
 mount -t overlay overlay -o lowerdir=${IOTEDGE_OVERLAY_RUN_LOWER_DIR},upperdir=${IOTEDGE_OVERLAY_RUN_UPPER_DIR},workdir=${IOTEDGE_OVERLAY_RUN_WORK_DIR} ${IOTEDGE_OVERLAY_RUN_LOWER_DIR}
+mount -t overlay overlay -o lowerdir=${JOURNAL_OVERLAY_RUN_LOWER_DIR},upperdir=${JOURNAL_OVERLAY_RUN_UPPER_DIR},workdir=${JOURNAL_OVERLAY_RUN_WORK_DIR} ${JOURNAL_OVERLAY_RUN_LOWER_DIR}
 
 # make lower dir of iotedge writeable. This needs to be done in order that iotedge can start properly.
 # meta-iotedge creates a user and group `iotedge:iotedge`. The service is run as this user.

--- a/recipes-overlays/overlay-directories/overlay-directories.inc
+++ b/recipes-overlays/overlay-directories/overlay-directories.inc
@@ -12,8 +12,3 @@ IOTEDGE_OVERLAY_RUN_ROOT_DIR ?= "/data"
 IOTEDGE_OVERLAY_RUN_LOWER_DIR ?= "/var/lib/iotedge"
 IOTEDGE_OVERLAY_RUN_UPPER_DIR ?= "/data/iotedge/var/lib/iotedge"
 IOTEDGE_OVERLAY_RUN_WORK_DIR ?= "/data/.overlay/iotedge-work/var/lib/iotedge"
-
-JOURNAL_OVERLAY_RUN_ROOT_DIR ?= "/data"
-JOURNAL_OVERLAY_RUN_LOWER_DIR ?= "/run/log/journal"
-JOURNAL_OVERLAY_RUN_UPPER_DIR ?= "/data/journal/run/log/journal"
-JOURNAL_OVERLAY_RUN_WORK_DIR ?= "/data/.overlay/journal-work/run/log/journal"

--- a/recipes-overlays/overlay-directories/overlay-directories.inc
+++ b/recipes-overlays/overlay-directories/overlay-directories.inc
@@ -12,3 +12,8 @@ IOTEDGE_OVERLAY_RUN_ROOT_DIR ?= "/data"
 IOTEDGE_OVERLAY_RUN_LOWER_DIR ?= "/var/lib/iotedge"
 IOTEDGE_OVERLAY_RUN_UPPER_DIR ?= "/data/iotedge/var/lib/iotedge"
 IOTEDGE_OVERLAY_RUN_WORK_DIR ?= "/data/.overlay/iotedge-work/var/lib/iotedge"
+
+JOURNAL_OVERLAY_RUN_ROOT_DIR ?= "/data"
+JOURNAL_OVERLAY_RUN_LOWER_DIR ?= "/run/log/journal"
+JOURNAL_OVERLAY_RUN_UPPER_DIR ?= "/data/journal/run/log/journal"
+JOURNAL_OVERLAY_RUN_WORK_DIR ?= "/data/.overlay/journal-work/run/log/journal"

--- a/recipes-overlays/persistent-journald/files/journald.conf
+++ b/recipes-overlays/persistent-journald/files/journald.conf
@@ -1,0 +1,43 @@
+#  This file is part of systemd.
+#
+#  systemd is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+#
+# Entries in this file show the compile time defaults.
+# You can change settings by editing this file.
+# Defaults can be restored by simply deleting this file.
+#
+# See journald.conf(5) for details.
+
+[Journal]
+Storage=auto
+#Compress=yes
+#Seal=yes
+#SplitMode=uid
+#SyncIntervalSec=5m
+#RateLimitIntervalSec=30s
+#RateLimitBurst=10000
+#SystemMaxUse=
+#SystemKeepFree=
+#SystemMaxFileSize=
+#SystemMaxFiles=100
+#RuntimeMaxUse=
+#RuntimeKeepFree=
+#RuntimeMaxFileSize=
+#RuntimeMaxFiles=100
+#MaxRetentionSec=
+#MaxFileSec=1month
+#ForwardToSyslog=yes
+#ForwardToKMsg=no
+#ForwardToConsole=no
+#ForwardToWall=yes
+#TTYPath=/dev/console
+#MaxLevelStore=debug
+#MaxLevelSyslog=debug
+#MaxLevelKMsg=notice
+#MaxLevelConsole=info
+#MaxLevelWall=emerg
+#LineMax=48K
+#ReadKMsg=yes

--- a/recipes-overlays/persistent-journald/files/persistent-journald.service
+++ b/recipes-overlays/persistent-journald/files/persistent-journald.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Redirects journald output to /data
+Requires=data.mount
+After=data.mount
+
+[Service]
+Type=oneshot
+RemainAfterExit=no
+ExecStart=/usr/bin/persistent-journald.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-overlays/persistent-journald/persistent-journald.bb
+++ b/recipes-overlays/persistent-journald/persistent-journald.bb
@@ -1,0 +1,49 @@
+inherit systemd
+
+require persistent-journald.inc
+
+SUMMARY = "Creates and mounts overlay directories for several modules used by meta-ci.os"
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+SRC_URI += "file://persistent-journald.service"
+SRC_URI += "file://journald.conf"
+
+SYSTEMD_SERVICE_${PN} = "persistent-journald.service"
+
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
+
+# ${bindir} expands to `/usr/bin/`
+JOURNALD_FLUSH_PERSISTENT_SCRIPT ?= "${bindir}/persistent-journald.sh"
+
+SYSTEMD_AUTO_ENABLE = "enable"
+
+do_install() {
+    install -d ${D}${bindir}
+    install -d ${D}${systemd_system_unitdir}
+    install -d ${D}${sysconfdir}/systemd
+    cat <<EOF > ${D}${JOURNALD_FLUSH_PERSISTENT_SCRIPT}
+#!/bin/sh
+# create journald overlay directories
+mkdir -p ${JOURNAL_OVERLAY_RUN_ROOT_DIR}
+mkdir -p ${JOURNAL_OVERLAY_RUN_LOWER_DIR}
+mkdir -p ${JOURNAL_OVERLAY_RUN_UPPER_DIR}
+mkdir -p ${JOURNAL_OVERLAY_RUN_WORK_DIR}
+
+# mount overlay
+mount -t overlay overlay -o lowerdir=${JOURNAL_OVERLAY_RUN_LOWER_DIR},upperdir=${JOURNAL_OVERLAY_RUN_UPPER_DIR},workdir=${JOURNAL_OVERLAY_RUN_WORK_DIR} ${JOURNAL_OVERLAY_RUN_LOWER_DIR}
+
+# flush to copy from volatile to persistent
+journalctl --flush
+EOF
+    install -m 0644 ${WORKDIR}/journald.conf ${D}${sysconfdir}/systemd
+    chmod +x ${D}${JOURNALD_FLUSH_PERSISTENT_SCRIPT}
+    install -m 0644 ${WORKDIR}/persistent-journald.service ${D}${systemd_system_unitdir}
+    
+}
+
+FILES_${PN} += "${sysconfdir}/systemd/journald.conf"
+FILES_${PN} += "${CREATE_OVERLAY_DIRECTORIES_SCRIPT}"
+FILES_${PN} += "${systemd_system_unitdir}/persistent-journald.service"
+
+REQUIRED_DISTRO_FEATURES= "systemd"

--- a/recipes-overlays/persistent-journald/persistent-journald.inc
+++ b/recipes-overlays/persistent-journald/persistent-journald.inc
@@ -1,0 +1,4 @@
+JOURNAL_OVERLAY_RUN_ROOT_DIR ?= "/data"
+JOURNAL_OVERLAY_RUN_LOWER_DIR ?= "/var/log/journal"
+JOURNAL_OVERLAY_RUN_UPPER_DIR ?= "/data/journal/var/log/journal"
+JOURNAL_OVERLAY_RUN_WORK_DIR ?= "/data/.overlay/journal-work/var/log/journal"


### PR DESCRIPTION
`journald`'s journal gets stored persistent via overlay partition in `/data/journal/var/log/journal` that is accessible at `/var/log/journal`

Each boot creates a new journal that can be accessed individually:
```
$ ls /var/log/journal
28b70d06a510434d8f66e0a4054e9ef9  734e4b04899b4371805c498e436c017c  aa9735a3aa3d4c3d842e9d137a6ab09f
$ journalctl -D /var/log/journal/aa9735a3aa3d4c3d842e9d137a6ab09f/ -u docker
-- Logs begin at Tue 2021-02-02 13:08:04 UTC, end at Tue 2021-02-02 13:28:43 UTC. --
$ journalctl -D /var/log/journal/28b70d06a510434d8f66e0a4054e9ef9/ -u docker
-- Logs begin at Tue 2021-02-02 13:48:39 UTC, end at Tue 2021-02-02 14:06:59 UTC. --
```

This PR incompanies ci4rail/ci.os.lmp/pull/10.
Merge (and rebase) this when #5 has been merged.