### PR TITLE
Feature/gpsd port expose

### DIFF
--- a/recipes-navigation/gpsd/files/etc_default_gpsd
+++ b/recipes-navigation/gpsd/files/etc_default_gpsd
@@ -1,6 +1,6 @@
 # Default settings for gpsd.
 START_DAEMON="true"
-GPSD_OPTIONS=""
+GPSD_OPTIONS="-G"
 DEVICES="/dev/ttymxc1"
 USBAUTO="true"
 GPSD_SOCKET="/var/run/gpsd.sock"

--- a/recipes-navigation/gpsd/files/gpsd.socket
+++ b/recipes-navigation/gpsd/files/gpsd.socket
@@ -1,0 +1,15 @@
+[Unit]
+Description=GPS (Global Positioning System) Daemon Sockets
+
+[Socket]
+# Allow access to gpsd port only from localhost and docker network
+ExecStartPre=iptables -A INPUT -p tcp -s 127.0.0.0/24 --dport 2947 -j ACCEPT
+ExecStartPre=iptables -A INPUT -p tcp -s 172.17.0.0/16 --dport 2947 -j ACCEPT
+ExecStartPre=iptables -A INPUT -p tcp -s 0.0.0.0/0 --dport 2947 -j DROP 
+ListenStream=/var/run/gpsd.sock
+ListenStream=[::1]:2947
+ListenStream=0.0.0.0:2947
+SocketMode=0600
+
+[Install]
+WantedBy=sockets.target

--- a/recipes-navigation/gpsd/gpsd_3.19.bbappend
+++ b/recipes-navigation/gpsd/gpsd_3.19.bbappend
@@ -1,9 +1,6 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 SRC_URI += "file://etc_default_gpsd"
 
-# For some reason, the original gpsd recipe doesn't start gpsd.service automatically (but gpsd.socket and gpsdctl@service)
-SYSTEMD_SERVICE_${PN} = "${BPN}.service ${BPN}.socket ${BPN}ctl@.service"
-
 do_install_append() {
      install -d ${D}/${sysconfdir}/default
      install -m 0644 ${WORKDIR}/etc_default_gpsd ${D}/${sysconfdir}/default/gpsd.default

--- a/recipes-navigation/gpsd/gpsd_3.19.bbappend
+++ b/recipes-navigation/gpsd/gpsd_3.19.bbappend
@@ -1,7 +1,9 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
-SRC_URI += "file://etc_default_gpsd"
+SRC_URI += "file://etc_default_gpsd \
+            file://gpsd.socket"
 
 do_install_append() {
      install -d ${D}/${sysconfdir}/default
      install -m 0644 ${WORKDIR}/etc_default_gpsd ${D}/${sysconfdir}/default/gpsd.default
+     install -m 0644 ${WORKDIR}/${BPN}.socket ${D}${systemd_unitdir}/system/${BPN}.socket
 }


### PR DESCRIPTION
* add firewall rules to gpsd - to expose socket for docker and localhost, but block it for external access.
* revert gpsd autostart change: starting gpsd.service is not necessary. It is started by gpsd.socket



